### PR TITLE
Replaces TMHOME with CMTHOME

### DIFF
--- a/ansible/templates/testappd.service.j2
+++ b/ansible/templates/testappd.service.j2
@@ -8,6 +8,7 @@ Type=simple
 User={{ ansible_user_id }}
 WorkingDirectory={{ ansible_user_dir }}
 ExecStart={{ansible_user_dir }}/go/bin/node {{ cmt_home }}config/app.toml
+Environment=TMHOME={{ cmt_home }}
 Environment=CMTHOME={{ cmt_home }}
 Restart=on-failure
 RestartSec=3


### PR DESCRIPTION
When running the qa tests in Digital Ocean, I had an error that `CMTHOME` was not set. Changing this fixes this error and I was able to deploy a testnet based on main. 

