### PR TITLE
Fixes for testing vote extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ RETRIEVE_TARGET_HOST ?= any
 EXPERIMENT_DIR=$(shell date "+%Y-%m-%d-%H_%M_%S%N")
 
 #VERSION_TAG ?= 3b783434f #v0.34.27 (cometbft/cometbft)
-VERSION_TAG ?= bef9a830e  #v0.37.alpha3 (cometbft/cometbft)
+#VERSION_TAG ?= bef9a830e  #v0.37.alpha3 (cometbft/cometbft)
+VERSION_TAG ?= 7d8c9d426 #main merged into feature/abci++vef + bugfixes
 VERSION2_TAG ?= 66c2cb634 #v0.34.26 (informalsystems/tendermint)
 VERSION_WEIGHT ?= 2
 VERSION2_WEIGHT ?= 0

--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -20,7 +20,7 @@
         name:
           - git
           - gcc
-          - golang-1.17-go
+          - golang-1.19-go
           - prometheus
           - prometheus-node-exporter
           - ntp

--- a/ansible/runload.yaml
+++ b/ansible/runload.yaml
@@ -12,6 +12,6 @@
 
   tasks:
     - name: install load tool
-      shell: "cd cometbft/test/loadtime/cmd/load/ && /usr/lib/go-1.17/bin/go install"
+      shell: "cd cometbft/test/loadtime/cmd/load/ && /usr/lib/go-1.19/bin/go install"
     - name: run the script
       shell: "/root/go/bin/load -c {{ connections }} -T {{ time_seconds }} -r {{ tx_per_second }} -s {{ size_bytes }} --broadcast-tx-method sync --endpoints {{endpoints}}"

--- a/ansible/update-testapp.yaml
+++ b/ansible/update-testapp.yaml
@@ -15,7 +15,7 @@
     - name: redirect https
       shell: "git config --global url.https://{{ go_modules_token }}@github.com/.insteadOf https://github.com/"
     - name: rebuild testapp
-      shell: "cd cometbft/test/e2e/node && GOPRIVATE=github.com/cometbft /usr/lib/go-1.17/bin/go install"
+      shell: "cd cometbft/test/e2e/node && GOPRIVATE=github.com/cometbft /usr/lib/go-1.19/bin/go install"
     - name: update unit file
       template:
         src: templates/testappd.service.j2

--- a/testnet.toml
+++ b/testnet.toml
@@ -1,3 +1,5 @@
+vote_extensions_enable_height = 1
+
 [node.validator00]
 seeds = ["seed01"]
 [node.validator01]

--- a/testnets/200node.toml
+++ b/testnets/200node.toml
@@ -1,3 +1,5 @@
+vote_extensions_enable_height = 1
+
 [node.seed0]
 mode = "seed"
 persistent_peers = ["seed1", "seed2", "seed3", "seed4"]

--- a/testnets/rotating.toml
+++ b/testnets/rotating.toml
@@ -1,3 +1,5 @@
+vote_extensions_enable_height = 1
+
 [node.validator00]
 seeds = ["seed00"]
 [node.validator01]


### PR DESCRIPTION
This PR tackles several problems:
 
* As vote extensions are disabled by default, we need to plan them into the genesis file. We use the existing config in the e2e manifest to do so.
* We need to update the scripts to go-1.19 (not possible yet to go-1.20 as it is not available via `apt`, so absolutely wanting to have go-1.20 now would have implied much more involved changes)