### PR TITLE
Propagate ssh retries into environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+ANSIBLE_SSH_RETRIES=5
 EPHEMERAL_SIZE ?= 0
 DO_INSTANCE_TAGNAME=v037-testnet
 LOAD_RUNNER_COMMIT_HASH ?= 51685158fe36869ab600527b852437ca0939d0cc
@@ -58,36 +59,36 @@ configgen:
 .PHONY: ansible-install
 ansible-install:
 	cd ansible && \
-		ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 ifneq ($(VERSION2_WEIGHT), 0)
 	cd ansible && \
-		ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 endif
 
 .PHONY: ansible-install-retry
 ansible-install-retry:
 	cd ansible && \
-		ANSIBLE_SSH_RETRIES=5 ansible-playbook -i retry -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i retry -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 ifneq ($(VERSION2_WEIGHT), 0)
 	cd ansible && \
-		ANSIBLE_SSH_RETRIES=5 ansible-playbook -i retry --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i retry --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 endif
 
 .PHONY: prometheus-init
 prometheus-init:
-	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts  -u root prometheus.yaml -f 10
+	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts  -u root prometheus.yaml -f 10
 
 .PHONY: start-network
 start-network:
-	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts -u root start-testapp.yaml -f $(ANSIBLE_FORKS)
+	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts -u root start-testapp.yaml -f $(ANSIBLE_FORKS)
 
 .PHONY: stop-network
 stop-network:
-	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts -u root stop-testapp.yaml -f $(ANSIBLE_FORKS)
+	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts -u root stop-testapp.yaml -f $(ANSIBLE_FORKS)
 
 .PHONY: runload
 runload:
-	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook runload.yaml -i hosts -u root \
+	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook runload.yaml -i hosts -u root \
 		-e endpoints=`ansible -i ./hosts --list-hosts validators | tail +2 | tail -1 | sed  "s/ //g" | sed 's/\(.*\)/ws:\/\/\1:26657\/websocket/' | paste -s -d, -` \
 		-e connections=$(ROTATE_CONNECTIONS) \
 		-e time_seconds=$(ROTATE_TOTAL_TIME) \
@@ -95,12 +96,12 @@ runload:
 
 .PHONY: restart
 restart:
-	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 ifneq ($(VERSION2_WEIGHT), 0)
-	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 endif
-	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook restart-prometheus.yaml -i hosts -u root
-	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook re-init-testapp.yaml -i hosts -u root -f $(ANSIBLE_FORKS)
+	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook restart-prometheus.yaml -i hosts -u root
+	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook re-init-testapp.yaml -i hosts -u root -f $(ANSIBLE_FORKS)
 
 .PHONY: rotate
 rotate:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-ANSIBLE_SSH_RETRIES=5
 EPHEMERAL_SIZE ?= 0
 DO_INSTANCE_TAGNAME=v037-testnet
 LOAD_RUNNER_COMMIT_HASH ?= 51685158fe36869ab600527b852437ca0939d0cc
@@ -58,37 +57,37 @@ configgen:
 
 .PHONY: ansible-install
 ansible-install:
-	cd ansible && ansible-playbook -i hosts -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+	cd ansible && \
+		ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 ifneq ($(VERSION2_WEIGHT), 0)
-	cd ansible && ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+	cd ansible && \
+		ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 endif
 
 .PHONY: ansible-install-retry
 ansible-install-retry:
-	cd ansible && ansible-playbook -i retry -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+	cd ansible && \
+		ANSIBLE_SSH_RETRIES=5 ansible-playbook -i retry -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 ifneq ($(VERSION2_WEIGHT), 0)
-	cd ansible && ansible-playbook -i retry --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+	cd ansible && \
+		ANSIBLE_SSH_RETRIES=5 ansible-playbook -i retry --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 endif
 
 .PHONY: prometheus-init
 prometheus-init:
-	cd ansible && ansible-playbook -i hosts  -u root prometheus.yaml -f 10
+	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts  -u root prometheus.yaml -f 10
 
 .PHONY: start-network
 start-network:
-	cd ansible && ansible-playbook -i hosts -u root start-testapp.yaml -f $(ANSIBLE_FORKS)
-
-.PHONY: start-network-retry
-start-network-retry:
-	cd ansible && ansible-playbook -i retry -u root start-testapp.yaml -f $(ANSIBLE_FORKS)
+	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts -u root start-testapp.yaml -f $(ANSIBLE_FORKS)
 
 .PHONY: stop-network
 stop-network:
-	cd ansible && ansible-playbook -i hosts -u root stop-testapp.yaml -f $(ANSIBLE_FORKS)
+	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts -u root stop-testapp.yaml -f $(ANSIBLE_FORKS)
 
 .PHONY: runload
 runload:
-	cd ansible && ansible-playbook runload.yaml -i hosts -u root \
+	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook runload.yaml -i hosts -u root \
 		-e endpoints=`ansible -i ./hosts --list-hosts validators | tail +2 | tail -1 | sed  "s/ //g" | sed 's/\(.*\)/ws:\/\/\1:26657\/websocket/' | paste -s -d, -` \
 		-e connections=$(ROTATE_CONNECTIONS) \
 		-e time_seconds=$(ROTATE_TOTAL_TIME) \
@@ -96,12 +95,12 @@ runload:
 
 .PHONY: restart
 restart:
-	cd ansible && ansible-playbook -i hosts -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 ifneq ($(VERSION2_WEIGHT), 0)
-	cd ansible && ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
 endif
-	cd ansible && ansible-playbook restart-prometheus.yaml -i hosts -u root
-	cd ansible && ansible-playbook re-init-testapp.yaml -i hosts -u root -f $(ANSIBLE_FORKS)
+	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook restart-prometheus.yaml -i hosts -u root
+	cd ansible && ANSIBLE_SSH_RETRIES=5 ansible-playbook re-init-testapp.yaml -i hosts -u root -f $(ANSIBLE_FORKS)
 
 .PHONY: rotate
 rotate:


### PR DESCRIPTION
This was something we wanted to do last time we tested.
It is propagating makefile var `ANSIBLE_SSH_RETRIES` into an environment variable with the same name whenever is necessary.