### PR TITLE
Added basic VPC infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,9 @@ stop-network:
 runload:
 	cd ansible && \
 		last_val=$$(ansible -i hosts --list-hosts validators | tail -1 | sed  "s/ //g") && \
+		endpoints=$$(ansible-inventory -i hosts -y --host $$last_val | grep 'internal_ip' | cut -d ' ' -f2 | sed 's/\(.*\)/ws:\/\/\1:26657\/websocket/' | paste -s -d, -) && \
 		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook runload.yaml -i hosts -u root \
-			-e endpoints=$$(ansible-inventory -i hosts -y --host $$last_val | grep 'internal_ip' | cut -d ' ' -f2 | sed 's/\(.*\)/ws:\/\/\1:26657\/websocket/' | paste -s -d, -) \
+			-e endpoints=$$endpoints \
 			-e connections=$(LOAD_CONNECTIONS) \
 			-e time_seconds=$(LOAD_TOTAL_TIME) \
 			-e tx_per_second=$(LOAD_TX_RATE) \
@@ -129,7 +130,7 @@ retrieve-blockstore:
 ifeq ($(RETRIEVE_TARGET_HOST), any)
 	cd ansible && \
 		last_val=$$(ansible -i hosts --list-hosts validators | tail -1 | sed  "s/ //g") && \
-		retrieve_target_host=$$(ansible-inventory -i hosts -y --host $$last_val | grep 'name' | cut -d ' ' -f2); \
+		retrieve_target_host=$$(ansible-inventory -i hosts -y --host $$last_val | grep 'name' | cut -d ' ' -f2) && \
 		ansible-playbook -i hosts -u root retrieve-blockstore.yaml -e "dir=../experiments/$(EXPERIMENT_DIR)/" -e "target_host=$$retrieve_target_host"
 else
 	cd ansible && \

--- a/Makefile
+++ b/Makefile
@@ -42,20 +42,20 @@ terraform-apply:
 .PHONY: hosts
 hosts:
 	echo "[validators]" > ./ansible/hosts
-	doctl compute droplet list --tag-name "testnet-node" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f2,3 | sort -k1 | sed 's/\(.*\) \(.*\)/\2 name=\1/g' >> ./ansible/hosts
+	doctl compute droplet list --tag-name "testnet-node" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f2,3,4 | sort -k1 | sed 's/\(.*\) \(.*\) \(.*\)/\2 name=\1 internal_ip=\3/g' >> ./ansible/hosts
 ifneq ($(VERSION2_WEIGHT), 0) #(num+den-1)/den is ceiling division
 	echo "[validators2]" >> ./ansible/hosts
-	total_validators=$$(doctl compute droplet list --tag-name "testnet-node" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f2,3 | sort -k1 | sed 's/\(.*\) \(.*\)/\2 name=\1/g' | wc -l) && \
+	total_validators=$$(doctl compute droplet list --tag-name "testnet-node" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f2,3,4 | sort -k1 | sed 's/\(.*\) \(.*\) \(.*\)/\2 name=\1 internal_ip=\3/g' | wc -l) && \
 	num=$$(( total_validators * $(VERSION2_WEIGHT) )) den=$$(( $(VERSION_WEIGHT)+$(VERSION2_WEIGHT) )) && \
 	vals2=$$(( (num+den-1)/den )) && \
-	doctl compute droplet list --tag-name "testnet-node" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f2,3 | sort -k1 | sed 's/\(.*\) \(.*\)/\2 name=\1/g' | tail -n $$vals2 >> ./ansible/hosts
+	doctl compute droplet list --tag-name "testnet-node" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f2,3,4 | sort -k1 | sed 's/\(.*\) \(.*\) \(.*\)/\2 name=\1 internal_ip=\3/g' | tail -n $$vals2 >> ./ansible/hosts
 endif
 	echo "[prometheus]" >> ./ansible/hosts
-	doctl compute droplet list --tag-name "testnet-observability" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f3   >> ./ansible/hosts
+	doctl compute droplet list --tag-name "testnet-observability" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f3,4 | sed 's/\(.*\) \(.*\)/\1 internal_ip=\2/g' >> ./ansible/hosts
 	echo "[loadrunners]" >> ./ansible/hosts
-	doctl compute droplet list --tag-name "testnet-load" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f3   >> ./ansible/hosts
+	doctl compute droplet list --tag-name "testnet-load" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f3,4 | sed 's/\(.*\) \(.*\)/\1 internal_ip=\2/g' >> ./ansible/hosts
 	echo "[ephemeral]" >> ./ansible/hosts
-	doctl compute droplet list --tag-name "ephemeral-node" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f2,3 | sort -k1 | sed 's/\(.*\) \(.*\)/\2 name=\1/g' >> ./ansible/hosts
+	doctl compute droplet list --tag-name "ephemeral-node" | tail -n+2 | grep $(DO_INSTANCE_TAGNAME) | tr -s ' ' | cut -d' ' -f2,3,4 | sort -k1 | sed 's/\(.*\) \(.*\) \(.*\)/\2 name=\1 internal_ip=\3/g' >> ./ansible/hosts
 
 .PHONY: configgen
 configgen:
@@ -97,12 +97,14 @@ stop-network:
 
 .PHONY: runload
 runload:
-	cd ansible && ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook runload.yaml -i hosts -u root \
-		-e endpoints=`ansible -i ./hosts --list-hosts validators | tail +2 | tail -1 | sed  "s/ //g" | sed 's/\(.*\)/ws:\/\/\1:26657\/websocket/' | paste -s -d, -` \
-		-e connections=$(LOAD_CONNECTIONS) \
-		-e time_seconds=$(LOAD_TOTAL_TIME) \
-		-e tx_per_second=$(LOAD_TX_RATE) \
-		-e iterations=$(ITERATIONS)
+	cd ansible && \
+		last_val=$$(ansible -i hosts --list-hosts validators | tail -1 | sed  "s/ //g") && \
+		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook runload.yaml -i hosts -u root \
+			-e endpoints=$$(ansible-inventory -i hosts -y --host $$last_val | grep 'internal_ip' | cut -d ' ' -f2 | sed 's/\(.*\)/ws:\/\/\1:26657\/websocket/' | paste -s -d, -) \
+			-e connections=$(LOAD_CONNECTIONS) \
+			-e time_seconds=$(LOAD_TOTAL_TIME) \
+			-e tx_per_second=$(LOAD_TX_RATE) \
+			-e iterations=$(ITERATIONS)
 
 .PHONY: restart
 restart:
@@ -126,7 +128,8 @@ retrieve-blockstore:
 	mkdir -p "./experiments/$(EXPERIMENT_DIR)"
 ifeq ($(RETRIEVE_TARGET_HOST), any)
 	cd ansible && \
-		retrieve_target_host=$$(ansible-inventory -i hosts --host $$(ansible -i hosts --list-hosts validators | tail -1) --yaml | sed 's/^name: //'); \
+		last_val=$$(ansible -i hosts --list-hosts validators | tail -1 | sed  "s/ //g") && \
+		retrieve_target_host=$$(ansible-inventory -i hosts -y --host $$last_val | grep 'name' | cut -d ' ' -f2); \
 		ansible-playbook -i hosts -u root retrieve-blockstore.yaml -e "dir=../experiments/$(EXPERIMENT_DIR)/" -e "target_host=$$retrieve_target_host"
 else
 	cd ansible && \

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 ANSIBLE_SSH_RETRIES=5
 EPHEMERAL_SIZE ?= 0
 DO_INSTANCE_TAGNAME=v038-testnet
+DO_VPC_SUBNET=172.19.144.0/20
 LOAD_RUNNER_COMMIT_HASH ?= 51685158fe36869ab600527b852437ca0939d0cc
 LOAD_RUNNER_CMD=go run github.com/cometbft/cometbft/test/e2e/runner@$(LOAD_RUNNER_COMMIT_HASH)
 ANSIBLE_FORKS=150
 export DO_INSTANCE_TAGNAME
+export DO_VPC_SUBNET
 export EPHEMERAL_SIZE
 LOAD_CONNECTIONS ?= 2
 LOAD_TX_RATE ?= 200
@@ -59,12 +61,12 @@ endif
 
 .PHONY: configgen
 configgen:
-	./script/configgen.sh $(VERSION_TAG) ./ansible/hosts
+	./script/configgen.sh $(VERSION_TAG) ./ansible/hosts $(DO_VPC_SUBNET)
 
 .PHONY: ansible-install
 ansible-install:
 	cd ansible && \
-		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)" -e "vpc_subnet=$(DO_VPC_SUBNET)"
 ifneq ($(VERSION2_WEIGHT), 0)
 	cd ansible && \
 		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i hosts --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
@@ -73,7 +75,7 @@ endif
 .PHONY: ansible-install-retry
 ansible-install-retry:
 	cd ansible && \
-		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i retry -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"
+		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i retry -u root install.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)" -e "vpc_subnet=$(DO_VPC_SUBNET)"
 ifneq ($(VERSION2_WEIGHT), 0)
 	cd ansible && \
 		ANSIBLE_SSH_RETRIES=$(ANSIBLE_SSH_RETRIES) ansible-playbook -i retry --limit validators2 -u root update-testapp.yaml -f $(ANSIBLE_FORKS) -e "version_tag=$(VERSION2_TAG)" -e "go_modules_token=$(GO_MODULES_TOKEN)"

--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -35,13 +35,13 @@
       community.general.ufw:
         rule: allow
         direction: in
-        to: 172.19.96.0/20
+        to: "{{vpc_subnet}}"
       become: yes
     - name: ufw - allow all outgoing traffic to private IPs
       community.general.ufw:
         rule: allow
         direction: out
-        to: 172.19.96.0/20
+        to: "{{vpc_subnet}}"
       become: yes
     - name: ufw - allow outgoing http traffic
       community.general.ufw:

--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -96,6 +96,14 @@
         to_port: 26657
         proto: tcp
       become: yes
+    - name: ufw - rate-limit incoming Comet gRPC
+      community.general.ufw:
+        rule: limit
+        direction: in
+        to: 0.0.0.0/0
+        to_port: 26670
+        proto: tcp
+      become: yes
     - name: ufw - enable
       community.general.ufw:
         state: enabled

--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -31,20 +31,6 @@
           - tmux
         state: latest
       become: yes
-    - name: ufw - reset
-      community.general.ufw:
-        state: reset
-      become: yes
-    - name: ufw - default deny incoming traffic
-      community.general.ufw:
-        default: deny
-        direction: incoming
-      become: yes
-    - name: ufw - default deny outgoing traffic
-      community.general.ufw:
-        default: deny
-        direction: outgoing
-      become: yes
     - name: ufw - allow all incoming traffic from private IPs
       community.general.ufw:
         rule: allow
@@ -107,4 +93,14 @@
     - name: ufw - enable
       community.general.ufw:
         state: enabled
+      become: yes
+    - name: ufw - default deny incoming traffic
+      community.general.ufw:
+        default: deny
+        direction: incoming
+      become: yes
+    - name: ufw - default deny outgoing traffic
+      community.general.ufw:
+        default: deny
+        direction: outgoing
       become: yes

--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -10,6 +10,7 @@
       ansible.builtin.apt:
         update_cache: yes
         cache_valid_time: 60
+      become: yes
     - name: restart systemd journal
       ansible.builtin.systemd:
         name: systemd-journald
@@ -26,6 +27,76 @@
           - ntp
           - ntpstat
           - jq
+          - ufw
           - tmux
         state: latest
+      become: yes
+    - name: ufw - reset
+      community.general.ufw:
+        state: reset
+      become: yes
+    - name: ufw - default deny incoming traffic
+      community.general.ufw:
+        default: deny
+        direction: incoming
+      become: yes
+    - name: ufw - default deny outgoing traffic
+      community.general.ufw:
+        default: deny
+        direction: outgoing
+      become: yes
+    - name: ufw - allow all incoming traffic from private IPs
+      community.general.ufw:
+        rule: allow
+        direction: in
+        to: 172.19.96.0/20
+      become: yes
+    - name: ufw - allow all outgoing traffic to private IPs
+      community.general.ufw:
+        rule: allow
+        direction: out
+        to: 172.19.96.0/20
+      become: yes
+    - name: ufw - allow outgoing http traffic
+      community.general.ufw:
+        rule: allow
+        direction: out
+        to: 0.0.0.0/0
+        to_port: http
+        proto: tcp
+      become: yes
+    - name: ufw - allow outgoing https traffic
+      community.general.ufw:
+        rule: allow
+        direction: out
+        to: 0.0.0.0/0
+        to_port: https
+        proto: tcp
+      become: yes
+    - name: ufw - allow outgoing dns traffic
+      community.general.ufw:
+        rule: allow
+        direction: out
+        to: 0.0.0.0/0
+        name: dns
+      become: yes
+    - name: ufw - rate-limit incoming ssh
+      community.general.ufw:
+        rule: limit
+        direction: in
+        to: 0.0.0.0/0
+        to_port: ssh
+        proto: tcp
+      become: yes
+    - name: ufw - rate-limit incoming Comet RPC
+      community.general.ufw:
+        rule: limit
+        direction: in
+        to: 0.0.0.0/0
+        to_port: 26657
+        proto: tcp
+      become: yes
+    - name: ufw - enable
+      community.general.ufw:
+        state: enabled
       become: yes

--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -80,25 +80,25 @@
         to: 0.0.0.0/0
         name: dns
       become: yes
-    - name: ufw - rate-limit incoming ssh
+    - name: ufw - allow incoming ssh
       community.general.ufw:
-        rule: limit
+        rule: allow
         direction: in
         to: 0.0.0.0/0
         to_port: ssh
         proto: tcp
       become: yes
-    - name: ufw - rate-limit incoming Comet RPC
+    - name: ufw - allow incoming Comet RPC
       community.general.ufw:
-        rule: limit
+        rule: allow
         direction: in
         to: 0.0.0.0/0
         to_port: 26657
         proto: tcp
       become: yes
-    - name: ufw - rate-limit incoming Comet gRPC
+    - name: ufw - allow incoming Comet gRPC
       community.general.ufw:
-        rule: limit
+        rule: allow
         direction: in
         to: 0.0.0.0/0
         to_port: 26670

--- a/ansible/prometheus.yaml
+++ b/ansible/prometheus.yaml
@@ -27,9 +27,9 @@
         state: restarted
         daemon_reload: yes
         enabled: yes
-    - name: ufw - rate-limit incoming prometheus http
+    - name: ufw - allow incoming prometheus http
       community.general.ufw:
-        rule: limit
+        rule: allow
         direction: in
         to: 0.0.0.0/0
         to_port: '9090'

--- a/ansible/prometheus.yaml
+++ b/ansible/prometheus.yaml
@@ -27,3 +27,10 @@
         state: restarted
         daemon_reload: yes
         enabled: yes
+    - name: ufw - rate-limit incoming prometheus http
+      community.general.ufw:
+        rule: limit
+        direction: in
+        to: 0.0.0.0/0
+        to_port: '9090'
+        proto: tcp

--- a/ansible/templates/prometheus.yml.j2
+++ b/ansible/templates/prometheus.yml.j2
@@ -9,14 +9,14 @@ scrape_configs:
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['{{ hostvars[host].inventory_hostname }}:26660']
+      - targets: ['{{ hostvars[host].internal_ip }}:26660']
 
   - job_name: {{ hostvars[host].name }}-node-exporter
 
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['{{ hostvars[host].inventory_hostname }}:9100']
+      - targets: ['{{ hostvars[host].internal_ip }}:9100']
 
 {% endfor %}
 
@@ -26,7 +26,7 @@ scrape_configs:
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['{{ hostvars[host].inventory_hostname }}:9100']
+      - targets: ['{{ hostvars[host].internal_ip }}:9100']
 
 {% endfor %}
 
@@ -36,13 +36,13 @@ scrape_configs:
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['{{ hostvars[host].inventory_hostname }}:26660']
+      - targets: ['{{ hostvars[host].internal_ip }}:26660']
 
   - job_name: {{ hostvars[host].name }}-node-exporter
 
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['{{ hostvars[host].inventory_hostname }}:9100']
+      - targets: ['{{ hostvars[host].internal_ip }}:9100']
 
 {% endfor %}

--- a/script/configgen.sh
+++ b/script/configgen.sh
@@ -21,11 +21,12 @@ fi
 ifd-from-ansible() {
 	HOST_PATH=$1
 	OUT_PATH=$2
+	VPC_SUBNET=$3
 	
 	cat <<EOF > $OUT_PATH
 {
 	"provider": "digital-ocean",
-	"network": "172.19.96.0/20",
+	"network": "$VPC_SUBNET",
 	"instances": {
 EOF
 	
@@ -63,9 +64,10 @@ EOF
 
 VERSION=$1
 HOSTS_PATH=$2
+VPC_SUBNET=$3
 IFD_PATH='./ifd.json'
 
-ifd-from-ansible $HOSTS_PATH $IFD_PATH
+ifd-from-ansible $HOSTS_PATH $IFD_PATH $VPC_SUBNET
 
 cp -p ./testnet.toml ./ansible
 rm -rf ./ansible/testnet

--- a/script/configgen.sh
+++ b/script/configgen.sh
@@ -25,7 +25,7 @@ ifd-from-ansible() {
 	cat <<EOF > $OUT_PATH
 {
 	"provider": "digital-ocean",
-	"network": "0.0.0.0/0",
+	"network": "172.19.96.0/20",
 	"instances": {
 EOF
 	
@@ -34,10 +34,12 @@ EOF
 	
 	i=1
 	for host in  $lines; do
-		ip=`echo $host | cut -d: -f1`
+		ext_ip=`echo $host | cut -d: -f1`
+		ip=`echo $host | cut -d: -f3 | cut -d= -f2`
 		name=`echo $host | cut -d: -f2 | sed -n 's/name=\(.*\)/\1/p'`
 		cat <<EOF >> $OUT_PATH
 		"$name": {
+			"ext_ip_address": "$ext_ip",
 			"ip_address": "$ip",
 			"port": 26657
 EOF

--- a/tf/Makefile
+++ b/tf/Makefile
@@ -6,6 +6,10 @@ ifndef EPHEMERAL_SIZE
 	$(error EPHEMERAL_SIZE is not set)
 endif
 
+ifndef DO_VPC_SUBNET
+	$(error DO_VPC_SUBNET is not set)
+endif
+
 EPHEMERAL_NAMES=$(shell for i in $$(seq 1 `expr $(EPHEMERAL_SIZE)`); do printf "\"ephemeral%03d\"\n" $$i; done | paste -s -d, -)
 TESTNET_SIZE=$(shell grep '^\[node.*\]' -c ../testnet.toml)
 INSTANCE_NAMES=$(shell grep '^\[node.*\]' ../testnet.toml | sed -e 's/^\[node\.\(.*\)]/"\1"/' | sort | paste -s -d, -)
@@ -26,7 +30,9 @@ apply: terraform.tfvars
 		-var='ephemeral_size=$(EPHEMERAL_SIZE)' \
 		-var='ephemeral_names=[$(EPHEMERAL_NAMES)]' \
 		-var='instance_tags=["$(DO_INSTANCE_TAGNAME)"]' \
-		-var='instance_names=[$(INSTANCE_NAMES)]' && \
+		-var='instance_names=[$(INSTANCE_NAMES)]' \
+		-var='vpc_subnet=$(DO_VPC_SUBNET)' \
+
 	terraform validate && \
 	terraform apply \
 		-parallelism=12 \
@@ -34,7 +40,9 @@ apply: terraform.tfvars
 		-var='ephemeral_size=$(EPHEMERAL_SIZE)' \
 		-var='ephemeral_names=[$(EPHEMERAL_NAMES)]' \
 		-var='instance_tags=["$(DO_INSTANCE_TAGNAME)"]' \
-		-var='instance_names=[$(INSTANCE_NAMES)]'
+		-var='instance_names=[$(INSTANCE_NAMES)]' \
+		-var='vpc_subnet=$(DO_VPC_SUBNET)' \
+
 
 .PHONY: destroy
 destroy: terraform.tfvars
@@ -44,4 +52,5 @@ destroy: terraform.tfvars
 		-var='ephemeral_size=$(EPHEMERAL_SIZE)' \
 		-var='ephemeral_names=[$(EPHEMERAL_NAMES)]' \
 		-var='instance_tags=["$(DO_INSTANCE_TAGNAME)"]' \
-		-var='instance_names=[$(INSTANCE_NAMES)]'
+		-var='instance_names=[$(INSTANCE_NAMES)]' \
+		-var='vpc_subnet=$(DO_VPC_SUBNET)' \

--- a/tf/nodes.tf
+++ b/tf/nodes.tf
@@ -30,7 +30,7 @@ variable "vpc_subnet" {
 }
 
 resource "digitalocean_vpc" "testnet-vpc" {
-  name     = "testnet-vpc-cometbft-sergio"
+  name     = replace("vpc-cometbft-${var.vpc_subnet}", "/[/.]/", "-")
   region   = "fra1"
   ip_range = var.vpc_subnet
 }

--- a/tf/nodes.tf
+++ b/tf/nodes.tf
@@ -25,10 +25,14 @@ variable "ephemeral_names" {
   type = list(string)
 }
 
+variable "vpc_subnet" {
+  type = string
+}
+
 resource "digitalocean_vpc" "testnet-vpc" {
-  name   = "testnet-vpc-cometbft"
-  region = "fra1"
-  ip_range = "172.19.96.0/20"
+  name     = "testnet-vpc-cometbft-sergio"
+  region   = "fra1"
+  ip_range = var.vpc_subnet
 }
 
 resource "digitalocean_droplet" "testnet-node" {

--- a/tf/nodes.tf
+++ b/tf/nodes.tf
@@ -25,6 +25,12 @@ variable "ephemeral_names" {
   type = list(string)
 }
 
+resource "digitalocean_vpc" "testnet-vpc" {
+  name   = "testnet-vpc-cometbft"
+  region = "fra1"
+  ip_range = "172.19.96.0/20"
+}
+
 resource "digitalocean_droplet" "testnet-node" {
   count    = var.testnet_size
   name     = var.instance_names[count.index]
@@ -32,6 +38,7 @@ resource "digitalocean_droplet" "testnet-node" {
   region   = "fra1"
   tags     = concat(var.instance_tags, ["testnet-node"])
   size     = "s-4vcpu-8gb"
+  vpc_uuid = digitalocean_vpc.testnet-vpc.id
   ssh_keys = var.ssh_keys
 }
 
@@ -41,6 +48,7 @@ resource "digitalocean_droplet" "testnet-prometheus" {
   region   = "fra1"
   tags     = concat(var.instance_tags, ["testnet-observability"])
   size     = "s-4vcpu-8gb"
+  vpc_uuid = digitalocean_vpc.testnet-vpc.id
   ssh_keys = var.ssh_keys
 }
 
@@ -50,6 +58,7 @@ resource "digitalocean_droplet" "testnet-load-runner" {
   region   = "fra1"
   tags     = concat(var.instance_tags, ["testnet-load"])
   size     = "s-8vcpu-16gb"
+  vpc_uuid = digitalocean_vpc.testnet-vpc.id
   ssh_keys = var.ssh_keys
 }
 
@@ -60,5 +69,6 @@ resource "digitalocean_droplet" "ephemeral-node" {
   region       = "fra1"
   tags         = concat(var.instance_tags, ["ephemeral-node"])
   size         = "s-4vcpu-8gb"
+  vpc_uuid     = digitalocean_vpc.testnet-vpc.id
   ssh_keys     = var.ssh_keys
 }


### PR DESCRIPTION
Closes #21 

This patch contains the following:

* terraform-based VPC creation
  * the subnet has been chosen to be easily extensible (i.e., having to change CIDR prefix) to up to ~8192 addresses (currently, 4096)
* adapting the `ansible/hosts` inventory file to carry each node's internal IP in a custom variable
* adapting all scripts and makefiles to operate with the new inventory format
* adapted `configgen` target to feed internal IP information to the e2e infrastructure file
  * with this, e2e runner can work in the new environment with no changes (!)
* added, to all nodes, the uncomplicated firewall (UFW) rules necessary for
  * unrestricted traffic within the VPC
  * no outgoing or incoming traffic on public interfaces by default, with the following exceptions
    * inbound ssh
    * outbound http, https (needed by, e.g., `apt`)
    * outbound dns
    * inbound CometBFT RPC
    * inbound CometBFT gRPC
* additionally, for the Prometheus node
  * inbound traffic on port 9090

The approach followed here is the simplest (i.e., requiring the least effort):

* no actual change in the way the user should proceed...
* ...whilst providing a fair level of security, and avoiding DO billing for node-to-node internal traffic

A more advanced approach (higher security, but roughly the same regarding DO billing) would be to have a gateway node, which routes all external traffic in and out of the other nodes, so they would _never_ use the external interface. However, at this moment, I think it would be overkill (cumbersome to use, more effort to implement, for no huge gains).