### PR TITLE
Upgrade scripts to use golang-1.21

### DIFF
--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -21,7 +21,7 @@
         name:
           - git
           - gcc
-          - golang-1.19-go
+          - golang-1.21-go
           - prometheus
           - prometheus-node-exporter
           - ntp

--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -24,7 +24,6 @@
           - golang-1.21-go
           - prometheus
           - prometheus-node-exporter
-          - ntp
           - ntpstat
           - jq
           - ufw

--- a/ansible/loadrunners-init.yaml
+++ b/ansible/loadrunners-init.yaml
@@ -8,7 +8,7 @@
         path: /root/go/bin/load
       register: load_tool
     - name: Install load tool
-      ansible.builtin.command: /usr/lib/go-1.19/bin/go install
+      ansible.builtin.command: /usr/lib/go-1.21/bin/go install
       args:
         chdir: /root/cometbft/test/loadtime/cmd/load/
       when: not load_tool.stat.exists

--- a/ansible/runload.yaml
+++ b/ansible/runload.yaml
@@ -14,7 +14,7 @@
 
   tasks:
     - name: install load tool
-      shell: "cd cometbft/test/loadtime/cmd/load/ && /usr/lib/go-1.19/bin/go install"
+      shell: "cd cometbft/test/loadtime/cmd/load/ && /usr/lib/go-1.21/bin/go install"
     - name: run the load tool
       shell: "/root/go/bin/load -c {{ connections }} -T {{ time_seconds }} -r {{ tx_per_second }} -s {{ size_bytes }} --broadcast-tx-method sync --endpoints {{endpoints}}"
       loop: "{{ range(0, iterations| int, 1)| list }}"

--- a/ansible/update-testapp.yaml
+++ b/ansible/update-testapp.yaml
@@ -15,7 +15,7 @@
     - name: redirect https
       shell: "git config --global url.https://{{ go_modules_token }}@github.com/.insteadOf https://github.com/"
     - name: rebuild testapp
-      shell: "cd cometbft/test/e2e/node && GOPRIVATE=github.com/cometbft /usr/lib/go-1.19/bin/go install"
+      shell: "cd cometbft/test/e2e/node && GOPRIVATE=github.com/cometbft /usr/lib/go-1.21/bin/go install"
     - name: update unit file
       template:
         src: templates/testappd.service.j2

--- a/tf/nodes.tf
+++ b/tf/nodes.tf
@@ -38,7 +38,7 @@ resource "digitalocean_vpc" "testnet-vpc" {
 resource "digitalocean_droplet" "testnet-node" {
   count    = var.testnet_size
   name     = var.instance_names[count.index]
-  image    = "debian-11-x64"
+  image    = "debian-12-x64"
   region   = "fra1"
   tags     = concat(var.instance_tags, ["testnet-node"])
   size     = "s-4vcpu-8gb"
@@ -48,7 +48,7 @@ resource "digitalocean_droplet" "testnet-node" {
 
 resource "digitalocean_droplet" "testnet-prometheus" {
   name     = "testnet-prometheus"
-  image    = "debian-11-x64"
+  image    = "debian-12-x64"
   region   = "fra1"
   tags     = concat(var.instance_tags, ["testnet-observability"])
   size     = "s-4vcpu-8gb"
@@ -58,7 +58,7 @@ resource "digitalocean_droplet" "testnet-prometheus" {
 
 resource "digitalocean_droplet" "testnet-load-runner" {
   name     = "testnet-load-runner"
-  image    = "debian-11-x64"
+  image    = "debian-12-x64"
   region   = "fra1"
   tags     = concat(var.instance_tags, ["testnet-load"])
   size     = "s-8vcpu-16gb"
@@ -69,7 +69,7 @@ resource "digitalocean_droplet" "testnet-load-runner" {
 resource "digitalocean_droplet" "ephemeral-node" {
   count        = var.ephemeral_size
   name         = var.ephemeral_names[count.index]
-  image        = "debian-11-x64"
+  image        = "debian-12-x64"
   region       = "fra1"
   tags         = concat(var.instance_tags, ["ephemeral-node"])
   size         = "s-4vcpu-8gb"


### PR DESCRIPTION
closes #27 

Also, this PR updates debian from v11 to v12, which is needed to install golang-1.21 with apt.