### PR TITLE
rename infrastructure port to rpc_port

### DIFF
--- a/script/configgen.sh
+++ b/script/configgen.sh
@@ -42,7 +42,7 @@ EOF
 		"$name": {
 			"ext_ip_address": "$ext_ip",
 			"ip_address": "$ip",
-			"port": 26657
+			"rpc_port": 26657
 EOF
 		if [ $i -lt $count ]; then
 			cat <<EOF >> $OUT_PATH


### PR DESCRIPTION
As per https://github.com/cometbft/cometbft/pull/1678, to differentiate between RPC and GRPC ports we renamed the variables. This changes creates an infrastructure file following this pattern. 

Should be merged after https://github.com/cometbft/cometbft/pull/1678/files 