### PR TITLE
Deduplicate and move configuration vars in a single place between Makefile and experiment.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+/ifd.json
 /tf/terraform.tfvars
 /tf/terraform.tfstate*
 /tf/.terraform/*
 /tf/.terraform.lock.hcl
+/ansible/testnet.toml
 /ansible/testnet/*
 /ansible/rotating/*
 /ansible/hosts

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 include experiment.mk
 
-DO_INSTANCE_TAGNAME=main-testnet
-DO_VPC_SUBNET=172.19.144.0/20
 LOAD_RUNNER_COMMIT_HASH ?= latest
 LOAD_RUNNER_CMD=go run github.com/cometbft/cometbft/test/e2e/runner@$(LOAD_RUNNER_COMMIT_HASH)
 ANSIBLE_SSH_RETRIES=5

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 include experiment.mk
 
+DO_INSTANCE_TAGNAME=main-testnet
 DO_VPC_SUBNET=172.19.144.0/20
 LOAD_RUNNER_COMMIT_HASH ?= latest
 LOAD_RUNNER_CMD=go run github.com/cometbft/cometbft/test/e2e/runner@$(LOAD_RUNNER_COMMIT_HASH)

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ After you have all the prerequisites installed and have configured your
     EOF
     ```
 
-4. If necessary, set the Makefile variables `DO_INSTANCE_TAGNAME` and
-    `DO_VPC_SUBNET` to customized values to prevent collisions with other users
-    of the DigitalOcean project who might be running these scripts.
+4. If necessary, set the variables `DO_INSTANCE_TAGNAME` and `DO_VPC_SUBNET`,
+    assigned in the `experiment.mk` file, to customized values to prevent
+    collisions with other QA runs, including possible other users of the
+    DigitalOcean project who might be running these scripts.
     If the subnet is allocated in the private IP address range 172.16.0.0/12, as
     it is in the unmodified assignment, a recommended choice should be
     in the range 172.16.16.0/20 - 172.31.240.0/20.

--- a/experiment.mk
+++ b/experiment.mk
@@ -1,17 +1,6 @@
 EPHEMERAL_SIZE ?= 0
-DO_INSTANCE_TAGNAME=main-testnet
 
 LOAD_CONNECTIONS ?= 2
 LOAD_TX_RATE ?= 200
 LOAD_TOTAL_TIME ?= 91
 ITERATIONS ?= 5
-
-# Set it to "all" to retrieve from all hosts
-# Set it to "any" to retrieve from one full node
-# Set it to the exact name of a validator to retrieve from it
-RETRIEVE_TARGET_HOST ?= any
-
-VERSION_TAG ?= 9ab4018a0f96b9144d9e2c0194d34596a8906627 # bucky limited concurrency
-#VERSION2_TAG ?= 66c2cb634 #v0.34.26 (informalsystems/tendermint)
-VERSION_WEIGHT ?= 1
-VERSION2_WEIGHT ?= 0

--- a/experiment.mk
+++ b/experiment.mk
@@ -1,3 +1,8 @@
+# Take care to make these values unique between experiments running
+# on the same DigitalOcean project.
+DO_INSTANCE_TAGNAME=main-testnet
+DO_VPC_SUBNET=172.19.144.0/20
+
 EPHEMERAL_SIZE ?= 0
 
 LOAD_CONNECTIONS ?= 2


### PR DESCRIPTION
Move the variables that are important for the Terraform configuration back to the `Makefile`. Deduplicate variable assignments in `experiment.mk` that are also present in `Makefile`. It's better to have the single place where these need to be defined, and I don't think the experiment parameters file is it.