### PR TITLE
refactor: Move VERSION_TAG variable from Makefile to experiment.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,12 @@
 include experiment.mk
 
-VERSION_TAG ?= f92bace91 # tag of main on 05.02.2024
-#VERSION_TAG ?= 3b783434f #v0.34.27 (cometbft/cometbft)
-#VERSION_TAG ?= bef9a830e  #v0.37.alpha3 (cometbft/cometbft)
-#VERSION_TAG ?= v0.38.0-alpha.2
-#VERSION_TAG ?= e9abb116e #v0.38.alpha2 (cometbft/cometbft)
-#VERSION_TAG ?= 9fc711b6514f99b2dc0864fc703cb81214f01783 #vote extension sizes.
-#VERSION_TAG ?= 7d8c9d426 #main merged into feature/abci++vef + bugfixes
-#VERSION2_TAG ?= 66c2cb634 #v0.34.26 (informalsystems/tendermint)
-VERSION_WEIGHT ?= 1
-VERSION2_WEIGHT ?= 0
+ifndef VERSION_TAG
+	$(error VERSION_TAG is not set)
+endif
+
+ifndef VERSION_WEIGHT
+	$(error VERSION_TAG is not set)
+endif
 
 ifeq ($(VERSION_WEIGHT), 0)
 $(error VERSION_WEIGHT must be non-zero)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ After you have set up the infrastructure:
 
 1. Set up the test you will run in the `experiment.mk` file:
     1. Set the path to your manifest file in the variable `MANIFEST`.
-    2. If necessary, set the variables `DO_INSTANCE_TAGNAME` and `DO_VPC_SUBNET` to customized
+    2. Set the commit hash of CometBFT that you to install in the nodes in the variable `VERSION_TAG`.
+    3. If you want to deploy a subset of the validators with a different version of CometBFT, set
+       the variable `VERSION2_TAG` to the commit hash you want to install in that subset. Then set
+       the proportion of nodes that will run `VERSION_TAG` and `VERSION2_TAG` in the variables
+       `VERSION_WEIGHT` and `VERSION2_WEIGHT` respectively.
+    4. If necessary, set the variables `DO_INSTANCE_TAGNAME` and `DO_VPC_SUBNET` to customized
     values to prevent collisions with other QA runs, including possible other users of the
     DigitalOcean project who might be running these scripts. If the subnet is allocated in the
     private IP address range 172.16.0.0/12, as it is in the unmodified file, a good choice should be

--- a/experiment.mk
+++ b/experiment.mk
@@ -3,9 +3,23 @@
 DO_INSTANCE_TAGNAME=main-testnet
 DO_VPC_SUBNET=172.19.144.0/20
 
-EPHEMERAL_SIZE ?= 0
-
 MANIFEST=$(realpath ./testnets/example.toml)
+
+VERSION_TAG ?= f92bace91 # tag of main on 05.02.2024
+#VERSION_TAG ?= 3b783434f #v0.34.27 (cometbft/cometbft)
+#VERSION_TAG ?= bef9a830e  #v0.37.alpha3 (cometbft/cometbft)
+#VERSION_TAG ?= v0.38.0-alpha.2
+#VERSION_TAG ?= e9abb116e #v0.38.alpha2 (cometbft/cometbft)
+#VERSION_TAG ?= 9fc711b6514f99b2dc0864fc703cb81214f01783 #vote extension sizes.
+#VERSION_TAG ?= 7d8c9d426 #main merged into feature/abci++vef + bugfixes
+
+VERSION_WEIGHT ?= 1
+
+## For testnets that mix nodes running different versions of CometBFT.
+#VERSION2_TAG ?= 66c2cb634 #v0.34.26 (informalsystems/tendermint)
+VERSION2_WEIGHT ?= 0
+
+EPHEMERAL_SIZE ?= 0
 
 LOAD_CONNECTIONS ?= 2
 LOAD_TX_RATE ?= 200


### PR DESCRIPTION
We want to put all variables that define an experiment or testnet in the file `experiment.mk`. We shouldn't change `Makefile` every time we want to run an experiment or deploy a testnet.