### PR TITLE
option to pull from insecure (custom setup) registry

### DIFF
--- a/tf/user-data.txt
+++ b/tf/user-data.txt
@@ -99,6 +99,12 @@ write_files:
       ExecStart=/usr/bin/prometheus-node-exporter
       [Install]
       WantedBy=multi-user.target
+write_files:
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "insecure-registries" : ["0.0.0.0/0"]
+      }
 runcmd:
   - ufw allow in from 10.0.0.0/8
   - ufw allow in from 172.16.0.0/12


### PR DESCRIPTION
This is a change that should help once we start leveraging docker images for QA testing. (Instead of the current systemd-based setup.)

This allows the nodes to download custom images from locally hosted repositories.

In practice, we can build one docker image with our custom binary, host it on one of the servers using Docker Registry and use a remote docker-compose call to pull down the image to the rest of the nodes and start running them automagically.

The problem is that `docker pull` defaults to using HTTPS (for good reason) and client-server certificates for authentication. This is overkill in our local-network or virtual-network setup.

If this feels insecure, we can start managing certificates or find a different way to deploy the images to the nodes. (docker-compose can build nodes remotely too.)

The change in itself doesn't have any impact right now.