### PR TITLE
fix: enable application logging in a node

### DIFF
--- a/tf/user-data.txt
+++ b/tf/user-data.txt
@@ -115,6 +115,7 @@ runcmd:
   - ufw default deny incoming
   - ufw default deny outgoing
   - systemctl daemon-reload
+  - systemctl force-reload systemd-journald
   - systemctl enable prometheus-node-exporter
   - systemctl start prometheus-node-exporter
   - systemctl enable docker


### PR DESCRIPTION
Currently it's not possible to see the logs of the testnet app running in a node. Running  `journalctl -u testapp` (after ssh) returns with the message `"No journal files were found."`. This PR forces to reload the config of `systemd-journald` to re-enable logging.

