### PR TITLE
Display file size before downloading

### DIFF
--- a/ansible/retrieve-blockstore.yaml
+++ b/ansible/retrieve-blockstore.yaml
@@ -12,23 +12,35 @@
         state: stopped
       become: yes
       when: target_host == "all" or target_host == hostvars[inventory_hostname].name
+
     - name: Delete old zip
       ansible.builtin.file:
         path: "{{ cmt_home }}/data/blockstore.db.zip"
         state: absent
       when: target_host == "all" or target_host == hostvars[inventory_hostname].name
+
     - name: Zip the blockstore directory
       archive:
         path: "{{ cmt_home }}/data/blockstore.db"
         format: zip
         dest: "{{ cmt_home }}/data/blockstore.db.zip"
       when: target_host == "all" or target_host == hostvars[inventory_hostname].name
+
+    - name: Fetch file size
+      stat:
+        path: "{{ cmt_home }}/data/blockstore.db.zip"
+      register: file_size
+
+    - name: Show file size
+      debug: msg="blockstore.db.zip={{ file_size.stat.size | filesizeformat(True) }}"
+
     - name: Fetch the blockstore
       ansible.builtin.fetch:
         src: "{{ cmt_home }}/data/blockstore.db.zip"
         dest: "{{dir}}/{{ hostvars[inventory_hostname].name }}/blockstore.db.zip"
         flat: yes
       when: target_host == "all" or target_host == hostvars[inventory_hostname].name
+
     - name: start the systemd-unit
       ansible.builtin.systemd:
         name: testappd

--- a/ansible/retrieve-blockstore.yaml
+++ b/ansible/retrieve-blockstore.yaml
@@ -30,9 +30,11 @@
       stat:
         path: "{{ cmt_home }}/data/blockstore.db.zip"
       register: file_size
+      when: target_host == "all" or target_host == hostvars[inventory_hostname].name
 
     - name: Show file size
       debug: msg="blockstore.db.zip={{ file_size.stat.size | filesizeformat(True) }}"
+      when: target_host == "all" or target_host == hostvars[inventory_hostname].name
 
     - name: Fetch the blockstore
       ansible.builtin.fetch:

--- a/ansible/retrieve-prometheus.yaml
+++ b/ansible/retrieve-prometheus.yaml
@@ -9,6 +9,15 @@
         path: "/var/lib/prometheus"
         format: zip
         dest: "/tmp/prometheus.zip"
+
+    - name: Fetch file size
+      stat:
+        path: "/tmp/prometheus.zip"
+      register: file_size
+
+    - name: Show file size
+      debug: msg="prometheus.zip={{ file_size.stat.size | filesizeformat(True) }}"
+
     - name: Fetch the prometheus dir
       ansible.builtin.fetch:
         src: "/tmp/prometheus.zip"


### PR DESCRIPTION
In Ansible, display to console the size of the file that is about to be downloaded. For prometheus and blockstore data, which can be pretty big.