### PR TITLE
feat: Scripts for generating images for QA reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /ansible/hosts
 /experiments
 **/.DS_Store
+**/.venv
+nohup.out

--- a/script/reports/latencies-gen-images.sh
+++ b/script/reports/latencies-gen-images.sh
@@ -41,7 +41,7 @@ pip install pandas matplotlib
 echo Generating latency/throughput image...
 python3 latency_throughput.py -t 'CometBFT: Latency vs Throughput' latency_throughput_$RELEASE_NAME.png results/raw.csv
 
-echo latency_plotter.py $RELEASE_NAME $CSV_PATH
+echo python3 latency_plotter.py $RELEASE_NAME $CSV_PATH
 python3 latency_plotter.py $RELEASE_NAME $CSV_PATH
 
 deactivate

--- a/script/reports/latencies-gen-images.sh
+++ b/script/reports/latencies-gen-images.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$1
+RELEASE_NAME=${2:-v1.0.0-alpha.2}
+CSV_PATH=${3:-results/raw.csv}
+COMET_COMMIT_HASH=${3:-e42f62b68} # v1.0.0-alpha.2
+
+[ -d "$DIR" ] || (echo "Error: directory '$DIR' not found"; exit 1)
+
+pushd "$DIR"
+ 
+if [ ! -d "$DIR/blockstore.db" ]; then
+    echo unzip blockstore.db.zip...
+    unzip -n blockstore.db.zip
+fi
+
+mkdir -p results
+if [ -f "results/raw.csv" ]; then
+    echo Generate results/raw.csv...
+    go run github.com/cometbft/cometbft/test/loadtime/cmd/report@$COMET_COMMIT_HASH --database-type goleveldb --data-dir ./ --csv results/raw.csv
+fi
+
+if [ -f "latency_throughput.py" ]; then
+    echo Download latency_throughput.py...
+    curl -s https://raw.githubusercontent.com/cometbft/cometbft/$COMET_COMMIT_HASH/scripts/qa/reporting/latency_throughput.py > latency_throughput.py
+fi
+
+if [ -f "latency_plotter.py" ];
+    echo Download latency_plotter.py...
+    curl -s https://raw.githubusercontent.com/cometbft/cometbft/$COMET_COMMIT_HASH/scripts/qa/reporting/latency_plotter.py > latency_plotter.py
+fi
+
+echo Setup Python virtual environment...
+python3 -m venv .venv && source .venv/bin/activate
+
+echo Install dependencies...
+pip install pandas matplotlib 
+
+echo Generating latency/throughput image...
+python3 latency_throughput.py -t 'CometBFT: Latency vs Throughput' latency_throughput_$RELEASE_NAME.png results/raw.csv
+
+echo latency_plotter.py $RELEASE_NAME $CSV_PATH
+python3 latency_plotter.py $RELEASE_NAME $CSV_PATH
+
+deactivate
+popd
+echo Done ✅

--- a/script/reports/prometheus-gen-images.sh
+++ b/script/reports/prometheus-gen-images.sh
@@ -3,19 +3,19 @@
 set -e
 
 SCRIPTS_COMMIT_HASH="e42f62b68" # v1.0.0-alpha.2
-RELEASE_NAME="v1.0.0-alpha.2" # name should not have spaces
 
 DIR=$1
 START_TIME=$2
 DURATION=$3
 TEST_CASE=${4:-200_nodes}
+RELEASE_NAME=${5:-"v1.0.0-alpha.2"} # name should not have spaces
 
 [ ! -z "$START_TIME" ] && [ ! -z "$DURATION" ] || (echo -e "Error: not enough arguments.\nUsage: $0 <dir> <start_time> <duration> [<test_case>]"; exit 1) 
 [ -d "$DIR" ] || (echo "Error: directory '$DIR' not found"; exit 1)
 [ -d "$DIR/prometheus" ] || (echo "Error: directory '$DIR/prometheus' not found"; exit 1)
 
 echo Check that a Prometheus server is running
-curl -s localhost:9090/status > /dev/null || (echo "Prometheus server is not running in localhost:9090; try with `dirname $0`/prometheus-start-local.sh"; exit 1)
+curl -s localhost:9090/status > /dev/null || (echo "Prometheus server is not running in localhost:9090; try with `dirname $0`/prometheus-start-local.sh $DIR"; exit 1)
 
 pushd "$DIR"
 
@@ -24,15 +24,13 @@ if [ ! -f "prometheus_plotter.py" ]; then
     curl -s https://raw.githubusercontent.com/cometbft/cometbft/$SCRIPTS_COMMIT_HASH/scripts/qa/reporting/prometheus_plotter.py > prometheus_plotter.py
 fi
 
-if [ ! -d ".venv" ]; then
-    echo Setup virtual environment...
-    python3 -m venv .venv && source .venv/bin/activate
+echo Setup virtual environment...
+python3 -m venv .venv && source .venv/bin/activate
 
-    echo Install dependencies...
-    pip install requests matplotlib pandas prometheus-pandas
-fi
+echo Install dependencies...
+pip install requests matplotlib pandas prometheus-pandas
 
-echo prometheus_plotter.py $RELEASE_NAME $START_TIME $DURATION $TEST_CASE
+echo python3 prometheus_plotter.py $RELEASE_NAME $START_TIME $DURATION $TEST_CASE
 python3 prometheus_plotter.py $RELEASE_NAME $START_TIME $DURATION $TEST_CASE
 
 deactivate

--- a/script/reports/prometheus-gen-images.sh
+++ b/script/reports/prometheus-gen-images.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPTS_COMMIT_HASH="e42f62b68" # v1.0.0-alpha.2
+RELEASE_NAME="v1.0.0-alpha.2" # name should not have spaces
+
+DIR=$1
+START_TIME=$2
+DURATION=$3
+TEST_CASE=${4:-200_nodes}
+
+[ ! -z "$START_TIME" ] && [ ! -z "$DURATION" ] || (echo -e "Error: not enough arguments.\nUsage: $0 <dir> <start_time> <duration> [<test_case>]"; exit 1) 
+[ -d "$DIR" ] || (echo "Error: directory '$DIR' not found"; exit 1)
+[ -d "$DIR/prometheus" ] || (echo "Error: directory '$DIR/prometheus' not found"; exit 1)
+
+echo Check that a Prometheus server is running
+curl -s localhost:9090/status > /dev/null || (echo "Prometheus server is not running in localhost:9090; try with `dirname $0`/prometheus-start-local.sh"; exit 1)
+
+pushd "$DIR"
+
+if [ ! -f "prometheus_plotter.py" ]; then
+    echo Download scripts...
+    curl -s https://raw.githubusercontent.com/cometbft/cometbft/$SCRIPTS_COMMIT_HASH/scripts/qa/reporting/prometheus_plotter.py > prometheus_plotter.py
+fi
+
+if [ ! -d ".venv" ]; then
+    echo Setup virtual environment...
+    python3 -m venv .venv && source .venv/bin/activate
+
+    echo Install dependencies...
+    pip install requests matplotlib pandas prometheus-pandas
+fi
+
+echo prometheus_plotter.py $RELEASE_NAME $START_TIME $DURATION $TEST_CASE
+python3 prometheus_plotter.py $RELEASE_NAME $START_TIME $DURATION $TEST_CASE
+
+deactivate
+popd
+echo Done ✅

--- a/script/reports/prometheus-start-local.sh
+++ b/script/reports/prometheus-start-local.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# This script starts a Prometheus server taking the data and configuration (prometheus.yml file)
+# found in a given directory (usually a directory with data from experiments). If there's no data
+# but it founds a prometheus.zip file, it will first unzip it. If there's another Prometheus
+# instance running, it will kill it first.
+
+set -e
+
+DIR=$1
+[ -d "$DIR" ] || (echo "Error: directory '$DIR' not found"; exit 1)
+
+CONFIG_FILE="$DIR/prometheus.yml"
+[ -f $CONFIG_FILE ] || (echo "Error: file '$CONFIG_FILE' not found"; exit 1)
+
+if [ ! -d "$DIR/prometheus" ]; then
+    ZIP_FILE="$DIR/prometheus.zip"
+    [ -f $ZIP_FILE ] || (echo "Error: file '$ZIP_FILE' not found"; exit 1)
+    
+    pushd "$DIR"
+    echo unzip $ZIP_FILE...
+    unzip -n `basename $ZIP_FILE`
+    popd
+fi
+
+# Kill any existing Prometheus server
+pkill -f prometheus &> /dev/null || true
+
+# Start Prometheus
+nohup prometheus --storage.tsdb.path $DIR/prometheus/ --config.file=$CONFIG_FILE &
+PROMETHEUS_PID=$!
+echo Started Prometheus with PID $PROMETHEUS_PID

--- a/script/reports/saturation-gen-table.sh
+++ b/script/reports/saturation-gen-table.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$1
+COMET_COMMIT_HASH=${2:-e42f62b68} # v1.0.0-alpha.2
+
+[ -d "$DIR" ] || (echo "Error: directory '$DIR' not found"; exit 1)
+
+pushd "$DIR"
+
+if [ ! -d "blockstore.db" ]; then
+    [ -f "blockstore.db.zip" ] || (echo "Error: file '$DIR/blockstore.db.zip' not found"; exit 1)
+    echo unzip blockstore.db.zip...
+    unzip -n blockstore.db.zip
+fi
+
+mkdir -p results
+
+echo Generating saturation table...
+
+# File `report.txt` contains an unordered list of experiments with varying concurrent connections
+# and transaction rate. We will need to separate the data per experiment.
+[ -f results/report.txt ] || go run github.com/cometbft/cometbft/test/loadtime/cmd/report@$COMET_COMMIT_HASH --database-type goleveldb --data-dir ./ > results/report.txt
+
+# Copy each experiment in `report.txt` into corresponding files `report<c>.txt`, where `c` is the
+# number of connections in the experiment. It is expected that experiments are sorted in ascending
+# tx rate order.
+for c in 1 2 4; do 
+    echo "$c"
+    file="results/report$c.txt"
+    res=`grep -s "Connections: $c" results/report.txt -B 2 -A 10` || true
+    if [ "$res" != "" ]; then 
+        echo "$res" > $file
+        # Replace tabs by spaces in all column files.
+        sed -i.bak 's/\t/    /g' $file
+    fi
+done
+
+# Generate `report_tabbed.txt` containing the results in matrix format. If the experiments use only
+# one connection, just copy the report to the final file. Otherwise, generate the matrix file by
+# putting the contents of `report<c>.txt` side by side. This effectively creates a table where rows
+# are a particular tx rate and columns are a particular number of websocket connections.
+if [ -f results/report2.txt ] && [ -f results/report4.txt ]; then 
+    # Combine the column files into a single table file. And merge the new column files into one.
+    paste results/report1.txt results/report2.txt results/report4.txt | column -s $'\t' -t > report_tabbed.txt
+else
+    cp results/report.txt report_tabbed.txt
+fi
+
+# Keep just the number of processed transactions in `saturation_table.tsv`.
+sed -i.bak 's/\t/    /g' report_tabbed.txt
+cat report_tabbed.txt | grep 'Valid Tx' | sed 's/Total Valid Tx://g' | tr -s ' ' > saturation_table.tsv
+
+popd
+echo Done ✅


### PR DESCRIPTION
Scripts to partly automate the [QA process](https://github.com/cometbft/cometbft/blob/main/docs/references/qa/method.md) when extracting results from experiments for generating reports. In particular, the 4 scripts help to extract data and images for finding the saturation point and comparing metrics.

For [obtaining the number of processed transactions, for the saturation point](https://github.com/cometbft/cometbft/blob/main/docs/references/qa/method.md#steps):
- `script/reports/saturation-gen-table.sh`: Generate a table of processed txs for each load instance.

For [plotting latencies, for the saturation point]:(https://github.com/cometbft/cometbft/blob/main/docs/references/qa/method.md#steps):
- `script/reports/latencies-gen-images.sh`: Generate images for each load instance with the latency of each block in the experiment.

For [extracting-prometheus-metrics](https://github.com/cometbft/cometbft/blob/main/docs/references/qa/method.md#extracting-prometheus-metrics):
- `script/reports/prometheus-start-local.sh`: Start a Prometheus server by bootstrapping a local database.
- `script/reports/prometheus-gen-images.sh`: Generate images from Prometheus metrics.

All scripts take as first parameter a directory with the results of the experiments from where to generate the images and tables.